### PR TITLE
Yuhao fix datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ site/
 # Data files
 data/**
 !data/**/.gitkeep
+data
 
 # Logs
 outputs/**

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Hydra config groups live under `configs/`:
 Override any value on the command line, for example:
 
 ```bash
-python3 -m dsr.cli.train model=transformer_medium train.training.batch_size=128
+python3 -m dsr.cli.train model=transformer_medium training.batch_size=128
 ```
 
 ### 5. Project Layout

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,5 +1,5 @@
 defaults:
-  - dataset@_global_: openwebtext
+  - dataset@_global_: openwebtext-modern
   - model: transformer_small
   - train@_global_: base
   - _self_

--- a/configs/dataset/openwebtext-modern.yaml
+++ b/configs/dataset/openwebtext-modern.yaml
@@ -1,5 +1,5 @@
 data:
-  train: openwebtext
+  train: Plamephia/openwebtext-modern
   valid: wikitext103
   cache_dir: ${paths.data_root}/raw
 


### PR DESCRIPTION
Fixed the datasets error.

The bug is due to the deprecated python scripts feature of HuggingFace.

Since we cannot update the original dataset, I downloaded all the data and repacked them into parquet format.

The new dataset called openwebtext-modern. Located in **_Plamephia/openwebtext-modern_**

I also fixed a README error.